### PR TITLE
HPO Terms annotation modified

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Install all the required packages:
 
 	$ venv/bin/pip install -r requirements.txt
 
-Create your database and the superuser by running this from the root directory of phenopacketscraper:
+Create your database and the superuser by running this from the `phenopacketscraper/` directory of the repository:
 
 	$ python manage.py migrate
 	$ python manage.py createsuperuser
@@ -49,8 +49,8 @@ To annotate data from a url you can enter the following in your browser:
 
 Or by using curl in your terminal. For annotation you can enter the following
 
-	$ curl -H 'Accept: application/json; indent=4' [url]
+	$ curl -H 'Accept: application/json; indent=4' http://localhost:8000/api/annotate/?url=[url]
 
-For instance you can use `http://molecularcasestudies.cshlp.org/content/2/2/a000703.abstract` in place for [url] for testing.
+For instance you can use `http://molecularcasestudies.cshlp.org/content/2/2/a000703.abstract` in place of [url] for testing.
 
 

--- a/phenopacketscraper/main/views.py
+++ b/phenopacketscraper/main/views.py
@@ -115,25 +115,27 @@ class AnnotateView(APIView):
 
             try:        
                 hpo_obs = gaussian.find_all("a", {"class": "kwd-search"})
+                hpo_terms= []
                 if hpo_obs:
-                    hpo_terms = ""
                     for ob in hpo_obs:
-                        hpo_terms += str(ob.text) + "\n"
-           
-                data = {'content' : hpo_terms}
+                        hpo_terms.append(str(ob.text).strip())
 
-                sci_graph_response = requests.get(server_url + '/annotations/entities', params = data)
+                response['Annotated HPO Terms'] = []
+                for term in hpo_terms:          
+                    data = {'content' : str(term)}
 
-                if sci_graph_response.status_code == 200:
-                    annotated_data = sci_graph_response.json()
-                    response['Annotated HPO Terms'] = str(annotated_data)
+                    sci_graph_response = requests.get(server_url + '/annotations/entities', params = data)
 
-                else:
-                    response['Annotated HPO Terms'] = ""
+                    if sci_graph_response.status_code == 200:
+                        annotated_data = sci_graph_response.json()
+                        response['Annotated HPO Terms'].append(str(annotated_data)) 
+
+                    else:
+                        response['Annotated HPO Terms'].append("")
 
 
             except:
-                response['Annotated HPO Terms'] = ""
+                response['Annotated HPO Terms'] = []
 
             return Response(response)  
         else:


### PR DESCRIPTION
Initially I was annotating the all of the HPO terms together. It is more useful to annotate termwise since that is the way it seems more applicable while generating phenopackets. So currently the annotated HPO terms part is a list of annotations of each term.

And I made the changes in the readme file as specified by you as it was more reasonable that way. The `[url]` instead of `http://localhost:8000/api/annotate/?url=[url]` was too misleading. 
